### PR TITLE
bugfix: Change default debug tool to nuclei_rv_debugger

### DIFF
--- a/boards/hbird_eval.json
+++ b/boards/hbird_eval.json
@@ -23,7 +23,10 @@
   },
   "debug": {
     "jlink_device": "RISC-V",
-    "svd_path": "HBIRD.svd"
+    "svd_path": "HBIRD.svd",
+    "onboard_tools": [
+      "nuclei-rv-debugger"
+    ]
   },
   "frameworks": [
     "nuclei-sdk"

--- a/builder/frameworks/_bare.py
+++ b/builder/frameworks/_bare.py
@@ -1,4 +1,5 @@
 # Copyright 2014-present PlatformIO <contact@platformio.org>
+# Copyright 2019-present Nuclei <contact@nucleisys.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/builder/frameworks/nuclei-sdk.py
+++ b/builder/frameworks/nuclei-sdk.py
@@ -1,4 +1,5 @@
 # Copyright 2019-present PlatformIO <contact@platformio.org>
+# Copyright 2019-present Nuclei <contact@nucleisys.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/builder/main.py
+++ b/builder/main.py
@@ -154,7 +154,7 @@ elif upload_protocol in debug_tools:
     else:
         openocd_args.extend([
             "-c", "reset halt; flash protect 0 0 last off;",
-            "-c", "program {$SOURCE} %s verify; reset; shutdown;" % program_start
+            "-c", "program {$SOURCE} verify; reset; shutdown;"
         ])
     env.Replace(
         UPLOADER="openocd",

--- a/builder/main.py
+++ b/builder/main.py
@@ -1,4 +1,5 @@
 # Copyright 2014-present PlatformIO <contact@platformio.org>
+# Copyright 2019-present Nuclei <contact@nucleisys.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/examples/freertos_demo/src/main.c
+++ b/examples/freertos_demo/src/main.c
@@ -1,3 +1,4 @@
+/* Copyright 2019-2020 Nuclei, Inc */
 /*
     FreeRTOS V9.0.0 - Copyright (C) 2016 Real Time Engineers Ltd.
     All rights reserved

--- a/examples/ucosii_demo/src/main.c
+++ b/examples/ucosii_demo/src/main.c
@@ -1,3 +1,5 @@
+/* Copyright 2019-2020 Nuclei, Inc */
+
 #include <stdint.h>
 #include <ucos_ii.h>
 

--- a/platform.json
+++ b/platform.json
@@ -12,7 +12,7 @@
     "type": "git",
     "url": "https://github.com/Nuclei-Software/platform-nuclei.git"
   },
-  "version": "0.0.1",
+  "version": "0.0.2",
   "packageRepositories": [
     "https://dl.bintray.com/platformio/dl-packages/manifest.json",
     "http://dl.platformio.org/packages/manifest.json",
@@ -32,7 +32,7 @@
     "framework-nuclei-sdk": {
       "optional": true,
       "type": "framework",
-      "version": "~0.1.0"
+      "version": "~0.1.1"
     },
     "tool-openocd-nuclei": {
       "optional": true,

--- a/platform.py
+++ b/platform.py
@@ -1,4 +1,5 @@
 # Copyright 2014-present PlatformIO <contact@platformio.org>
+# Copyright 2019-present Nuclei <contact@nucleisys.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
* Change the default `debug_tool` of `hbird` to `nuclei_rv_debugger`, otherwise it will use `jlink`, which is not supported by `hbird` board
* When upload program to `flash`, no need to provide `flash_start`, because we are using elf file, openocd can parse the address and program it, if you provide it, it will cause other issues, program will fail with verify failing issue