### PR TITLE
Basic platform files refactoring  

### DIFF
--- a/boards/gd32vf103v_eval.json
+++ b/boards/gd32vf103v_eval.json
@@ -1,40 +1,39 @@
 {
-    "build": {
-        "f_cpu": "108000000L",
-        "hwids": [
-            [
-                "0x0403",
-                "0x6010"
-            ]
-        ],
-        "ldscript": "",
-        "mabi": "ilp32",
-        "march": "rv32imac",
-        "mcmodel": "medlow",
-        "soc": "gd32vf103",
-        "mcu": "GD32VF103VBT6",
-        "download": "flashxip",
-        "download_modes": [
-            "flashxip"
-        ]
-    },
-    "debug": {
-        "jlink_device": "GD32VF103VBT6",
-        "svd_path": "GD32VF103.svd"
-    },
-    "frameworks": [
-        "nuclei-sdk"
+  "build": {
+    "f_cpu": "108000000L",
+    "hwids": [
+      [
+        "0x0403",
+        "0x6010"
+      ]
     ],
-    "name": "GD32VF103V Evaluation Kit",
-    "upload": {
-        "maximum_ram_size": 32768,
-        "maximum_size": 131072,
-        "flash_start": "0x08000000",
-        "protocol": "nuclei-rv-debugger",
-        "protocols": [
-            "nuclei-rv-debugger"
-        ]
-    },
-    "url": "https://www.gigadevice.com/",
-    "vendor": "GigaDevice"
+    "mabi": "ilp32",
+    "march": "rv32imac",
+    "mcmodel": "medlow",
+    "soc": "gd32vf103",
+    "mcu": "gd32vf103vbt6",
+    "download": "flashxip",
+    "download_modes": [
+      "flashxip"
+    ]
+  },
+  "debug": {
+    "jlink_device": "GD32VF103VBT6",
+    "svd_path": "GD32VF103.svd"
+  },
+  "frameworks": [
+    "nuclei-sdk"
+  ],
+  "name": "GD32VF103V Evaluation Kit",
+  "upload": {
+    "maximum_ram_size": 32768,
+    "maximum_size": 131072,
+    "flash_start": "0x08000000",
+    "protocol": "nuclei-rv-debugger",
+    "protocols": [
+      "nuclei-rv-debugger"
+    ]
+  },
+  "url": "https://www.gigadevice.com/",
+  "vendor": "GigaDevice"
 }

--- a/boards/gd32vf103v_rvstar.json
+++ b/boards/gd32vf103v_rvstar.json
@@ -1,43 +1,43 @@
 {
-    "build": {
-        "f_cpu": "108000000L",
-        "hwids": [
-            [
-                "0x0403",
-                "0x6010"
-            ]
-        ],
-        "ldscript": "",
-        "mabi": "ilp32",
-        "march": "rv32imac",
-        "mcmodel": "medlow",
-        "soc": "gd32vf103",
-        "mcu": "GD32VF103VBT6",
-        "download": "flashxip",
-        "download_modes": [
-            "flashxip"
-        ]
-    },
-    "debug": {
-        "jlink_device": "GD32VF103VBT6",
-        "svd_path": "GD32VF103.svd",
-        "onboard_tools": [
-          "nuclei-rv-debugger"
-        ]
-    },
-    "frameworks": [
-        "nuclei-sdk"
+  "build": {
+    "f_cpu": "108000000L",
+    "hwids": [
+      [
+        "0x0403",
+        "0x6010"
+      ]
     ],
-    "name": "GD32VF103V RVStar Kit",
-    "upload": {
-        "maximum_ram_size": 32768,
-        "maximum_size": 131072,
-        "flash_start": "0x08000000",
-        "protocol": "nuclei-rv-debugger",
-        "protocols": [
-            "nuclei-rv-debugger"
-        ]
-    },
-    "url": "https://nucleisys.com/",
-    "vendor": "Nuclei"
+    "ldscript": "",
+    "mabi": "ilp32",
+    "march": "rv32imac",
+    "mcmodel": "medlow",
+    "soc": "gd32vf103",
+    "mcu": "gd32vf103vbt6",
+    "download": "flashxip",
+    "download_modes": [
+      "flashxip"
+    ]
+  },
+  "debug": {
+    "jlink_device": "GD32VF103VBT6",
+    "svd_path": "GD32VF103.svd",
+    "onboard_tools": [
+      "nuclei-rv-debugger"
+    ]
+  },
+  "frameworks": [
+    "nuclei-sdk"
+  ],
+  "name": "GD32VF103V RVStar Kit",
+  "upload": {
+    "maximum_ram_size": 32768,
+    "maximum_size": 131072,
+    "flash_start": "0x08000000",
+    "protocol": "nuclei-rv-debugger",
+    "protocols": [
+      "nuclei-rv-debugger"
+    ]
+  },
+  "url": "https://nucleisys.com/",
+  "vendor": "Nuclei"
 }

--- a/boards/hbird_eval.json
+++ b/boards/hbird_eval.json
@@ -1,45 +1,44 @@
 {
-    "build": {
-        "f_cpu": "5000000L",
-        "hwids": [
-            [
-                "0x0403",
-                "0x6010"
-            ]
-        ],
-        "ldscript": "",
-        "mcmodel": "medany",
-        "soc": "hbird",
-        "mcu": "HummingBird",
-        "core": "n307fd",
-        "download": "flash",
-        "download_modes": [
-            "ilm",
-            "flash",
-            "flashxip"
-        ]
-    },
-    "debug": {
-        "jlink_device": "RISC-V",
-        "svd_path": "HBIRD.svd",
-        "onboard_tools": [
-            "nuclei-rv-debugger"
-        ]
-    },
-    "frameworks": [
-        "nuclei-sdk"
+  "build": {
+    "f_cpu": "5000000L",
+    "hwids": [
+      [
+        "0x0403",
+        "0x6010"
+      ]
     ],
-    "name": "HummingBird Evaluation Kit",
-    "upload": {
-        "maximum_ram_size": 65536,
-        "maximum_size": 65536,
-        "ilm_start": "0x80000000",
-        "flash_start": "0x20000000",
-        "protocol": "nuclei-rv-debugger",
-        "protocols": [
-            "nuclei-rv-debugger"
-        ]
-    },
-    "url": "https://nucleisys.com/",
-    "vendor": "Nuclei"
+    "mcmodel": "medany",
+    "soc": "hbird",
+    "mcu": "HummingBird",
+    "core": "n307fd",
+    "download": "flash",
+    "download_modes": [
+      "ilm",
+      "flash",
+      "flashxip"
+    ]
+  },
+  "debug": {
+    "jlink_device": "RISC-V",
+    "svd_path": "HBIRD.svd",
+    "onboard_tools": [
+      "nuclei-rv-debugger"
+    ]
+  },
+  "frameworks": [
+    "nuclei-sdk"
+  ],
+  "name": "HummingBird Evaluation Kit",
+  "upload": {
+    "maximum_ram_size": 65536,
+    "maximum_size": 65536,
+    "ilm_start": "0x80000000",
+    "flash_start": "0x20000000",
+    "protocol": "nuclei-rv-debugger",
+    "protocols": [
+      "nuclei-rv-debugger"
+    ]
+  },
+  "url": "https://nucleisys.com/",
+  "vendor": "Nuclei"
 }

--- a/builder/frameworks/_bare.py
+++ b/builder/frameworks/_bare.py
@@ -21,8 +21,6 @@ from SCons.Script import Import
 
 Import("env")
 
-board_config = env.BoardConfig()
-
 env.Append(
     CCFLAGS=[
         "-Os",

--- a/examples/helloworld/platformio.ini
+++ b/examples/helloworld/platformio.ini
@@ -18,9 +18,11 @@ monitor_speed = 115200
 
 [env:nuclei-hbird_eval]
 board = hbird_eval
+board_build.download = flash
 
 [env:nuclei-gd32vf103v_rvstar]
 board = gd32vf103v_rvstar
+board_build.download = flashxip
 
 [env:nuclei-gd32vf103v_eval]
 board = gd32vf103v_eval


### PR DESCRIPTION
This PR includes some basic refactoring:
- Board manifests are now consistent with other platforms (removed empty fields, updated indentation)
- Basic refactoring of python scripts (added missing imports, removed code duplication, allowed using custom linker scripts via `board_build.script = file.ld` syntax and a few other small changes)
- Extended config for `helloworld` example in order to test ldscript selection process in the nuclei-sdk build script

Thanks in advance!